### PR TITLE
Per language configuration support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "HiDeoo",
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
-    "vscode": "^1.18.0"
+    "vscode": "^1.42.0"
   },
   "categories": [
     "Other"
@@ -91,8 +91,10 @@
       "title": "Toggler",
       "properties": {
         "toggler.toggles": {
+          "scope": "language-overridable",
           "type": "array",
-          "default": [
+          "uniqueItems": true,
+          "examples": [
             [
               "absolute",
               "relative"
@@ -105,6 +107,7 @@
           "description": "Custom toggles."
         },
         "toggler.useDefaultToggles": {
+          "scope": "language-overridable",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Toggler is bundled with some [default toggles](https://raw.githubusercontent.com/HiDeoo/toggler-vscode/master/src/defaults.json) merged with your custom ones that you can disable if they don't fit your preferences."
@@ -124,7 +127,7 @@
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.11.0",
-    "@types/vscode": "1.18.0",
+    "@types/vscode": "1.42.0",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "eslint": "^6.8.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ export function activate(context: ExtensionContext) {
       openTogglerSettings()
     }),
     workspace.onDidChangeConfiguration(() => {
-      loadConfiguration(true)
+      loadConfiguration()
     })
   )
 }
@@ -51,12 +51,8 @@ export function deactivate() {
  * Loads the configuration.
  * @param reload - Defines if the configuration should be reloaded or not.
  */
-function loadConfiguration(reload = false) {
-  if (configuration && !reload) {
-    return
-  }
-
-  const togglerConfiguration = workspace.getConfiguration('toggler')
+function loadConfiguration() {
+  const togglerConfiguration = workspace.getConfiguration('toggler', window.activeTextEditor?.document)
 
   const useDefaultToggles = togglerConfiguration.get<boolean>('useDefaultToggles', true)
   const customToggles = togglerConfiguration.get<ToggleConfiguration[]>('toggles', [])


### PR DESCRIPTION
This PR adds per-language configuration support 

- Changed vscode engine
- Added `language-overridable` scope to settings
   - Altered `default` schema to `examples` for toggles since each language will have respective needs
   - Added `uniqueItems` schema property
- Removed `reload` constraint since cached configurations will conflict with respective language configurations

resources [ [Configuration Schema](https://code.visualstudio.com/api/references/contribution-points#Configuration-schema) | [Minimum Version](https://code.visualstudio.com/updates/v1_42#_languagespecific-settings) ]