### PR TITLE
Add language-specific custom toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+The extension now requires at least [Visual Studio Code 1.42.0 _(January 2020)_](https://code.visualstudio.com/updates/v1_42).
+
+### 🚀 New Feature
+
+- TODO
+
 ## 0.1.1
 
 ### 🚀 New Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The extension now requires at least [Visual Studio Code 1.42.0 _(January 2020)_]
 
 ### 🚀 New Feature
 
-- TODO
+- Add support for [language-specific](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings) custom toggles.
+
+### 🐛 Bug Fix
+
+- Prevent reloading the extension configuration when unrelated Visual Studio Code settings are modified.
 
 ## 0.1.1
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "HiDeoo",
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
-    "vscode": "^1.18.0"
+    "vscode": "^1.42.0"
   },
   "categories": [
     "Other"
@@ -124,7 +124,7 @@
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.11.0",
-    "@types/vscode": "1.18.0",
+    "@types/vscode": "1.42.0",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
               "low"
             ]
           ],
-          "description": "Custom toggles."
+          "description": "Custom toggles.",
+          "scope": "language-overridable"
         },
         "toggler.useDefaultToggles": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,8 +38,10 @@ export function activate(context: ExtensionContext) {
     commands.registerCommand(TogglerCommands.Settings, () => {
       openTogglerSettings()
     }),
-    workspace.onDidChangeConfiguration(() => {
-      resetConfiguration()
+    workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('toggler')) {
+        resetConfiguration()
+      }
     })
   )
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ const RegExpCharacters = /[|\\{}()[\]^$+*?.]/g
 /**
  * Toggler configuration.
  */
-let configuration: ToggleConfiguration[] | undefined
+let configuration: Record<string, ToggleConfiguration[]> | undefined
 
 /**
  * Triggered when the extension is activated (the very first time the command is executed).
@@ -27,6 +27,10 @@ let configuration: ToggleConfiguration[] | undefined
 export function activate(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand(TogglerCommands.Toggle, () => {
+      if (!window.activeTextEditor) {
+        return
+      }
+
       loadConfiguration()
 
       return toggle()
@@ -35,7 +39,7 @@ export function activate(context: ExtensionContext) {
       openTogglerSettings()
     }),
     workspace.onDidChangeConfiguration(() => {
-      loadConfiguration(true)
+      resetConfiguration()
     })
   )
 }
@@ -48,20 +52,46 @@ export function deactivate() {
 }
 
 /**
- * Loads the configuration.
- * @param reload - Defines if the configuration should be reloaded or not.
+ * Resets the configuration.
  */
-function loadConfiguration(reload = false) {
-  if (configuration && !reload) {
+function resetConfiguration() {
+  configuration = undefined
+}
+
+/**
+ * Loads the configuration.
+ */
+function loadConfiguration() {
+  if (!window.activeTextEditor) {
     return
   }
 
-  const togglerConfiguration = workspace.getConfiguration('toggler')
+  const languageId = window.activeTextEditor.document.languageId
+
+  if (configuration && configuration[languageId]) {
+    return
+  }
+
+  if (!configuration) {
+    configuration = {}
+  }
+
+  let customToggles: ToggleConfiguration[] = []
+
+  const togglerConfiguration = workspace.getConfiguration('toggler', window.activeTextEditor?.document)
 
   const useDefaultToggles = togglerConfiguration.get<boolean>('useDefaultToggles', true)
-  const customToggles = togglerConfiguration.get<ToggleConfiguration[]>('toggles', [])
+  const customTogglesInfos = togglerConfiguration.inspect<ToggleConfiguration[]>('toggles')
 
-  configuration = useDefaultToggles ? customToggles.concat(defaults) : customToggles
+  if (customTogglesInfos) {
+    if (customTogglesInfos.globalLanguageValue) {
+      customToggles = customTogglesInfos.globalLanguageValue
+    } else if (customTogglesInfos.globalValue) {
+      customToggles = customTogglesInfos.globalValue
+    }
+  }
+
+  configuration[languageId] = useDefaultToggles ? customToggles.concat(defaults) : customToggles
 }
 
 /**
@@ -134,16 +164,18 @@ function getToggle(editor: TextEditor, selection: Selection): Toggle {
     selected,
   }
 
-  if (!configuration) {
+  if (!configuration || !configuration[editor.document.languageId]) {
     return toggle
   }
+
+  const languageConfiguration = configuration[editor.document.languageId]
 
   if (!selected) {
     lineText = editor.document.lineAt(cursorPosition).text
   }
 
-  for (let i = 0; i < configuration.length; i++) {
-    const words = configuration[i]
+  for (let i = 0; i < languageConfiguration.length; i++) {
+    const words = languageConfiguration[i]
 
     for (let j = 0; j < words.length; j++) {
       const currentWord = words[j]

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -150,7 +150,7 @@ suite('Toggler Test Suite', () => {
       },
       { global: { useDefaultToggles: false } }
     )
-  })
+  }).timeout(10000)
 
   test('should replace a global custom toggle', () => {
     return withEditor(
@@ -165,7 +165,7 @@ suite('Toggler Test Suite', () => {
         language: [['json', { toggles: [['aaa', 'ccc']] }]],
       }
     )
-  })
+  }).timeout(10000)
 
   test('should replace a language-specific custom toggle', () => {
     return withEditor(
@@ -184,4 +184,4 @@ suite('Toggler Test Suite', () => {
       }
     )
   })
-})
+}).timeout(10000)

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -139,4 +139,16 @@ suite('Toggler Test Suite', () => {
       assertDocumentTextEqual(document, '"')
     })
   })
+
+  test('should not use default toggles if the option is globally disabled', () => {
+    return withEditor(
+      'true',
+      async (document) => {
+        await commands.executeCommand(TogglerCommands.Toggle)
+
+        assertDocumentTextEqual(document, 'true')
+      },
+      { useDefaultToggles: false }
+    )
+  })
 })

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -140,7 +140,7 @@ suite('Toggler Test Suite', () => {
     })
   })
 
-  test('should not use default toggles if the option is globally disabled', () => {
+  test('should not use default toggles if the option is disabled', () => {
     return withEditor(
       'true',
       async (document) => {
@@ -148,11 +148,11 @@ suite('Toggler Test Suite', () => {
 
         assertDocumentTextEqual(document, 'true')
       },
-      { useDefaultToggles: false }
+      { global: { useDefaultToggles: false } }
     )
   })
 
-  test('should replace a custom toggle', () => {
+  test('should replace a global custom toggle', () => {
     return withEditor(
       'aaa',
       async (document) => {
@@ -160,7 +160,28 @@ suite('Toggler Test Suite', () => {
 
         assertDocumentTextEqual(document, 'bbb')
       },
-      { toggles: [['aaa', 'bbb']] }
+      {
+        global: { toggles: [['aaa', 'bbb']] },
+        language: [['json', { toggles: [['aaa', 'ccc']] }]],
+      }
+    )
+  })
+
+  test('should replace a language-specific custom toggle', () => {
+    return withEditor(
+      'aaa',
+      async (document) => {
+        await commands.executeCommand(TogglerCommands.Toggle)
+
+        assertDocumentTextEqual(document, 'ccc')
+      },
+      {
+        global: { toggles: [['aaa', 'bbb']] },
+        language: [
+          ['plaintext', { toggles: [['aaa', 'ccc']] }],
+          ['json', { toggles: [['aaa', 'ddd']] }],
+        ],
+      }
     )
   })
 })

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -151,4 +151,16 @@ suite('Toggler Test Suite', () => {
       { useDefaultToggles: false }
     )
   })
+
+  test('should replace a custom toggle', () => {
+    return withEditor(
+      'aaa',
+      async (document) => {
+        await commands.executeCommand(TogglerCommands.Toggle)
+
+        assertDocumentTextEqual(document, 'bbb')
+      },
+      { toggles: [['aaa', 'bbb']] }
+    )
+  })
 })

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -52,9 +52,17 @@ async function setSettings(settings: ExtensionSettings): Promise<ExtensionSettin
   const togglerConfiguration = workspace.getConfiguration('toggler')
 
   if (typeof settings.useDefaultToggles !== 'undefined') {
-    currentSettings.useDefaultToggles = togglerConfiguration.get<boolean>('useDefaultToggles')
+    currentSettings.useDefaultToggles = togglerConfiguration.get<ExtensionSettings['useDefaultToggles']>(
+      'useDefaultToggles'
+    )
 
     await togglerConfiguration.update('useDefaultToggles', settings.useDefaultToggles, true)
+  }
+
+  if (settings.toggles) {
+    currentSettings.toggles = togglerConfiguration.get<ExtensionSettings['toggles']>('toggles')
+
+    await togglerConfiguration.update('toggles', settings.toggles, true)
   }
 
   return currentSettings
@@ -65,4 +73,5 @@ async function setSettings(settings: ExtensionSettings): Promise<ExtensionSettin
  */
 interface ExtensionSettings {
   useDefaultToggles?: boolean
+  toggles?: string[][]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,10 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/vscode@1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.18.0.tgz#6fdb2ab1510cd225a37827b3858446295640c8c7"
-  integrity sha512-OpY9CvSzX3cqBjNTJHTtkj7SMIORLlfVBiY7rNs6hy8TQiOyU+b0zWXQ9iN3lnmk6KFbXyulmeZw5HkmlY4sWw==
+"@types/vscode@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.42.0.tgz#0ad891a9487e91e34be7c56985058a179031eb76"
+  integrity sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==
 
 "@typescript-eslint/eslint-plugin@^2.30.0":
   version "2.34.0"


### PR DESCRIPTION
This pull request adds support for [language-specific](https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings) custom toggles.
